### PR TITLE
changes needed for compiling successfully on Ubuntu 14.04 ... 

### DIFF
--- a/code/BROCCOLI_LIB/broccoli_lib.h
+++ b/code/BROCCOLI_LIB/broccoli_lib.h
@@ -425,6 +425,9 @@ class BROCCOLI_LIB
 		// High level functions
 		//------------------------------------------------
 
+		void SetupGLMFirstLevel(int REGRESSORS);
+		void CleanupGLMFirstLevel(); 
+		
 		void PerformRegistrationEPIT1();
 		void PerformRegistrationEPIT1_();
 		void PerformRegistrationT1MNI();

--- a/code/BROCCOLI_LIB/compile_broccoli_library.sh
+++ b/code/BROCCOLI_LIB/compile_broccoli_library.sh
@@ -21,8 +21,10 @@ if [ "$OPENCL_PACKAGE" -eq "$AMD" ] ; then
     OPENCL_HEADER_DIRECTORY2=/opt/AMDAPP/include/CL 
 # Need to install Intel OpenCL SDK first
 elif [ "$OPENCL_PACKAGE" -eq "$INTEL" ] ; then
-    OPENCL_HEADER_DIRECTORY1=/opt/intel/opencl-sdk/include 
-    OPENCL_HEADER_DIRECTORY2=/opt/intel/opencl-sdk/include/CL
+    # OPENCL_HEADER_DIRECTORY1=/opt/intel/opencl-sdk/include 
+    # OPENCL_HEADER_DIRECTORY2=/opt/intel/opencl-sdk/include/CL
+    OPENCL_HEADER_DIRECTORY1=/opt/intel/intel-opencl-1.2-4.6.0.92/opencl-sdk/include
+    OPENCL_HEADER_DIRECTORY2=/opt/intel/intel-opencl-1.2-4.6.0.92/opencl-sdk/include/CL
 # Need to install Nvidia CUDA SDK first
 elif [ "$OPENCL_PACKAGE" -eq "$NVIDIA" ] ; then
     OPENCL_HEADER_DIRECTORY1=/usr/include/CL 

--- a/code/Bash_Wrapper/compile_wrappers_alternate.sh
+++ b/code/Bash_Wrapper/compile_wrappers_alternate.sh
@@ -6,8 +6,8 @@ BROCCOLI_GIT_DIRECTORY=`git rev-parse --show-toplevel`
 AMD=0
 INTEL=1
 NVIDIA=2
-OPENCL_PACKAGE=$AMD
-#OPENCL_PACKAGE=$INTEL
+#OPENCL_PACKAGE=$AMD
+OPENCL_PACKAGE=$INTEL
 #OPENCL_PACKAGE=$NVIDIA
 
 # Set compilation mode to use
@@ -28,9 +28,12 @@ if [ "$OPENCL_PACKAGE" -eq "$AMD" ]; then
     OPENCL_LIBRARY_DIRECTORY=/opt/AMDAPP/lib/x86_64 
 # Need to install Intel OpenCL SDK and Intel OpenCL runtime first
 elif [ "$OPENCL_PACKAGE" -eq "$INTEL" ]; then
-    OPENCL_HEADER_DIRECTORY1=/opt/intel/opencl-sdk/include 
-    OPENCL_HEADER_DIRECTORY2=/opt/intel/opencl-sdk/include/CL
-    OPENCL_LIBRARY_DIRECTORY=/opt/intel/opencl/lib64
+    #OPENCL_HEADER_DIRECTORY1=/opt/intel/opencl-sdk/include 
+    #OPENCL_HEADER_DIRECTORY2=/opt/intel/opencl-sdk/include/CL
+    #OPENCL_LIBRARY_DIRECTORY=/opt/intel/opencl/lib64
+    OPENCL_HEADER_DIRECTORY1=/opt/intel/intel-opencl-1.2-4.6.0.92/opencl-sdk/include
+    OPENCL_HEADER_DIRECTORY2=/opt/intel/intel-opencl-1.2-4.6.0.92/opencl-sdk/include/CL
+    OPENCL_LIBRARY_DIRECTORY=/opt/intel/intel-opencl-1.2-4.6.0.92/opencl/lib64
 # Need to install Nvidia CUDA SDK first
 elif [ "$OPENCL_PACKAGE" -eq "$NVIDIA" ]; then
     OPENCL_HEADER_DIRECTORY1=/usr/local/cuda-6.5/include/CL
@@ -52,20 +55,20 @@ else
     echo "Unknown compilation mode"
 fi
 
-g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen GetOpenCLInfo.cpp -lOpenCL -lBROCCOLI_LIB ${FLAGS} -o GetOpenCLInfo
+g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen GetOpenCLInfo.cpp -lBROCCOLI_LIB ${FLAGS} -lOpenCL -o GetOpenCLInfo
 
 # Support for compressed files
-g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib MotionCorrection.cpp -lOpenCL -lBROCCOLI_LIB -lniftiio -lznz -lz ${FLAGS} -o MotionCorrection 
+g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib MotionCorrection.cpp -lBROCCOLI_LIB -lOpenCL -lniftiio -lznz -lz ${FLAGS} -o MotionCorrection 
 
-g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib RegisterTwoVolumes.cpp -lOpenCL -lBROCCOLI_LIB -lniftiio -lznz -lz ${FLAGS} -o RegisterTwoVolumes
+g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib RegisterTwoVolumes.cpp -lBROCCOLI_LIB -lOpenCL -lniftiio -lznz -lz ${FLAGS} -o RegisterTwoVolumes
 
-g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib TransformVolume.cpp -lOpenCL -lBROCCOLI_LIB -lniftiio -lznz -lz ${FLAGS} -o TransformVolume
+g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib TransformVolume.cpp -lBROCCOLI_LIB -lOpenCL -lniftiio -lznz -lz ${FLAGS} -o TransformVolume
 
-g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib RandomiseGroupLevel.cpp -lOpenCL -lBROCCOLI_LIB -lniftiio -lznz -lz ${FLAGS} -o RandomiseGroupLevel
+g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib RandomiseGroupLevel.cpp -lBROCCOLI_LIB -lOpenCL -lniftiio -lznz -lz ${FLAGS} -o RandomiseGroupLevel
 
-g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib FirstLevelAnalysis.cpp -lOpenCL -lBROCCOLI_LIB -lniftiio -lznz -lz ${FLAGS} -o FirstLevelAnalysis
+g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib FirstLevelAnalysis.cpp -lBROCCOLI_LIB -lOpenCL -lniftiio -lznz -lz ${FLAGS} -o FirstLevelAnalysis
 
-g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib SliceTimingCorrection.cpp -lOpenCL -lBROCCOLI_LIB -lniftiio -lznz -lz ${FLAGS} -o SliceTimingCorrection
+g++ -I${OPENCL_HEADER_DIRECTORY1} -I${OPENCL_HEADER_DIRECTORY2} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -L${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/lib -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib SliceTimingCorrection.cpp -lBROCCOLI_LIB -lOpenCL -lniftiio -lznz -lz ${FLAGS} -o SliceTimingCorrection
 
 # No support for compressed files
 #g++ RegisterTwoVolumes.cpp ${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib/nifti1_io.c ${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib/znzlib.c -lOpenCL -lBROCCOLI_LIB -I${OPENCL_HEADER_DIRECTORY} -L${OPENCL_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/ -L${BROCCOLI_LIBRARY_DIRECTORY} -I${BROCCOLI_GIT_DIRECTORY}/code/BROCCOLI_LIB/Eigen -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/niftilib -I${BROCCOLI_GIT_DIRECTORY}/code/Bash_Wrapper/nifticlib-2.0.0/znzlib -o RegisterTwoVolumes


### PR DESCRIPTION
with intel's opencl sdk.
Hi @wanderine. These are the changes I had to apply. The broccoli lib needs to be linked before the lOpenCl. Now it compiles flawlessly. The alternate compile script might not be necessary if you change the order in the normal script and it still works for you and on other systems.
